### PR TITLE
Added support for more key formats for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ See https://github.com/sicpa-dlab/didcomm-demo.
 - Java 8+
 - In order to use the library, `SecretResolver` and `DIDDocResolver` interfaces must be implemented on the application level.
   Implementation of that interfaces is out of DIDComm library scope.
-    - Verification materials in DID Docs and secrets are expected in JWK format only.
+    - Verification materials are expected in JWK, Base58 and Multibase formats.
+        - In Base58 and Multibase formats, keys using only X25519 and Ed25519 curves are supported.
+        - For private keys in Base58 and Multibase formats, the verification material value contains both private and public parts (concatenated bytes).
+        - In Multibase format, bytes of the verification material value is prefixed with the corresponding Multicodec code.
     - Key IDs (kids) used in `SecretResolver` must match the corresponding key IDs from DID Doc verification methods.
     - Key IDs (kids) in DID Doc verification methods and secrets must be a full [DID Fragment](https://www.w3.org/TR/did-core/#fragment), that is `did#key-id`.
     - Verification methods referencing another DID Document are not supported (see [Referring to Verification Methods](https://www.w3.org/TR/did-core/#referring-to-verification-methods)).

--- a/lib/src/main/kotlin/org/didcommx/didcomm/crypto/JWS.kt
+++ b/lib/src/main/kotlin/org/didcommx/didcomm/crypto/JWS.kt
@@ -104,6 +104,9 @@ fun getJWSAlgorithm(jwk: JWK) = when (jwk) {
         Curve.SECP256K1 -> JWSAlgorithm.ES256K
         else -> throw UnsupportedCurveException(jwk.curve.name)
     }
-    is OctetKeyPair -> JWSAlgorithm.EdDSA
+    is OctetKeyPair -> when (jwk.curve) {
+        Curve.Ed25519 -> JWSAlgorithm.EdDSA
+        else -> throw UnsupportedCurveException(jwk.curve.name)
+    }
     else -> throw UnsupportedJWKException(jwk.javaClass.name)
 }

--- a/lib/src/main/kotlin/org/didcommx/didcomm/utils/MulticodecUtils.kt
+++ b/lib/src/main/kotlin/org/didcommx/didcomm/utils/MulticodecUtils.kt
@@ -5,7 +5,9 @@ import java.nio.ByteBuffer
 
 enum class Codec(val prefix: Int) {
     X25519_PUB(0xEC),
-    ED25519_PUB(0xED);
+    ED25519_PUB(0xED),
+    ED25519_PRIV(0x1300),
+    X25519_PRIV(0x1302),
 }
 
 fun fromMulticodec(value: ByteArray): Pair<Codec, ByteArray> {

--- a/lib/src/test/kotlin/org/didcommx/didcomm/crypto/key/ExtractKeyTest.kt
+++ b/lib/src/test/kotlin/org/didcommx/didcomm/crypto/key/ExtractKeyTest.kt
@@ -43,6 +43,39 @@ class ExtractKeyTest {
     }
 
     @Test
+    fun `Test_extract_OKP_key_from_JsonWebKey2020_secret`() {
+        val key = Key.fromSecret(
+            Secret(
+                kid = "did:example:alice#key-ed25519-2",
+                type = VerificationMethodType.JSON_WEB_KEY_2020,
+                verificationMaterial = VerificationMaterial(
+                    format = VerificationMaterialFormat.JWK,
+                    value = """
+                        {
+                            "kty": "OKP",
+                            "crv": "Ed25519",
+                            "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
+                            "d": "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY"
+                        }
+                    """.trimIndent(),
+                ),
+            )
+        )
+
+        assertEquals("did:example:alice#key-ed25519-2", key.id)
+        assertEquals(Curve.Ed25519, key.curve)
+        assertEquals(
+            mapOf(
+                "kty" to "OKP",
+                "crv" to "Ed25519",
+                "x" to "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
+                "d" to "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY",
+            ),
+            key.jwk.toJSONObject(),
+        )
+    }
+
+    @Test
     fun `Test_extract_EC_key_from_JsonWebKey2020_verification_method`() {
         val key = Key.fromVerificationMethod(
             VerificationMethod(
@@ -71,39 +104,6 @@ class ExtractKeyTest {
                 "crv" to "P-256",
                 "x" to "L0crjMN1g0Ih4sYAJ_nGoHUck2cloltUpUVQDhF2nHE",
                 "y" to "SxYgE7CmEJYi7IDhgK5jI4ZiajO8jPRZDldVhqFpYoo",
-            ),
-            key.jwk.toJSONObject(),
-        )
-    }
-
-    @Test
-    fun `Test_extract_OKP_key_from_JsonWebKey2020_secret`() {
-        val key = Key.fromSecret(
-            Secret(
-                kid = "did:example:alice#key-ed25519-2",
-                type = VerificationMethodType.JSON_WEB_KEY_2020,
-                verificationMaterial = VerificationMaterial(
-                    format = VerificationMaterialFormat.JWK,
-                    value = """
-                        {
-                            "kty": "OKP",
-                            "crv": "Ed25519",
-                            "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
-                            "d": "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY"
-                        }
-                    """.trimIndent(),
-                ),
-            )
-        )
-
-        assertEquals("did:example:alice#key-ed25519-2", key.id)
-        assertEquals(Curve.Ed25519, key.curve)
-        assertEquals(
-            mapOf(
-                "kty" to "OKP",
-                "crv" to "Ed25519",
-                "x" to "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
-                "d" to "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY",
             ),
             key.jwk.toJSONObject(),
         )
@@ -171,6 +171,32 @@ class ExtractKeyTest {
     }
 
     @Test
+    fun `Test_extract_key_from_X25519KeyAgreementKey2019_secret`() {
+        val key = Key.fromSecret(
+            Secret(
+                kid = "did:example:eve#key-x25519-1",
+                type = VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2019,
+                verificationMaterial = VerificationMaterial(
+                    format = VerificationMaterialFormat.BASE58,
+                    value = "2b5J8uecvwAo9HUGge5NKQ7HoRNKUKCjZ7Fr4mDgWkwqFyjLPWt7rv5kL3UPeG3e4B9Sy4H2Q2zAuWcP2RNtgJ4t",
+                ),
+            )
+        )
+
+        assertEquals("did:example:eve#key-x25519-1", key.id)
+        assertEquals(Curve.X25519, key.curve)
+        assertEquals(
+            mapOf(
+                "kty" to "OKP",
+                "crv" to "X25519",
+                "x" to "piw5XSMkceDeklaHQZXPBLQySyAwF8eZ-vddihdURS0",
+                "d" to "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
+            ),
+            key.jwk.toJSONObject(),
+        )
+    }
+
+    @Test
     fun `Test_extract_key_from_Ed25519VerificationKey2018_verification_method`() {
         val key = Key.fromVerificationMethod(
             VerificationMethod(
@@ -191,6 +217,32 @@ class ExtractKeyTest {
                 "kty" to "OKP",
                 "crv" to "Ed25519",
                 "x" to "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA",
+            ),
+            key.jwk.toJSONObject(),
+        )
+    }
+
+    @Test
+    fun `Test_extract_key_from_Ed25519VerificationKey2018_secret`() {
+        val key = Key.fromSecret(
+            Secret(
+                kid = "did:example:eve#key-ed25519-1",
+                type = VerificationMethodType.ED25519_VERIFICATION_KEY_2018,
+                verificationMaterial = VerificationMaterial(
+                    format = VerificationMaterialFormat.BASE58,
+                    value = "2b5J8uecvwAo9HUGge5NKQ7HoRNKUKCjZ7Fr4mDgWkwqATnLmZDx7Seu6NqTuFKkxuHNT27GcoxVZQCkWJhNvaUQ",
+                ),
+            )
+        )
+
+        assertEquals("did:example:eve#key-ed25519-1", key.id)
+        assertEquals(Curve.Ed25519, key.curve)
+        assertEquals(
+            mapOf(
+                "kty" to "OKP",
+                "crv" to "Ed25519",
+                "x" to "VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE",
+                "d" to "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
             ),
             key.jwk.toJSONObject(),
         )
@@ -223,6 +275,32 @@ class ExtractKeyTest {
     }
 
     @Test
+    fun `Test_extract_key_from_X25519KeyAgreementKey2020_secret`() {
+        val key = Key.fromSecret(
+            Secret(
+                kid = "did:example:eve#key-x25519-2",
+                type = VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2020,
+                verificationMaterial = VerificationMaterial(
+                    format = VerificationMaterialFormat.MULTIBASE,
+                    value = "zshCmpUZKtFrAfudMf7NzD3oR6yhWe6i2434FDktk9CYZfkndn7suDrqnRWvrVDHk95Z7vBRJChFxTgBF9qzq7D3xPe",
+                ),
+            )
+        )
+
+        assertEquals("did:example:eve#key-x25519-2", key.id)
+        assertEquals(Curve.X25519, key.curve)
+        assertEquals(
+            mapOf(
+                "kty" to "OKP",
+                "crv" to "X25519",
+                "x" to "piw5XSMkceDeklaHQZXPBLQySyAwF8eZ-vddihdURS0",
+                "d" to "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
+            ),
+            key.jwk.toJSONObject(),
+        )
+    }
+
+    @Test
     fun `Test_extract_key_from_Ed25519VerificationKey2020_verification_method`() {
         val key = Key.fromVerificationMethod(
             VerificationMethod(
@@ -243,6 +321,32 @@ class ExtractKeyTest {
                 "kty" to "OKP",
                 "crv" to "Ed25519",
                 "x" to "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA",
+            ),
+            key.jwk.toJSONObject(),
+        )
+    }
+
+    @Test
+    fun `Test_extract_key_from_Ed25519VerificationKey2020_secret`() {
+        val key = Key.fromSecret(
+            Secret(
+                kid = "did:example:eve#key-ed25519-2",
+                type = VerificationMethodType.ED25519_VERIFICATION_KEY_2020,
+                verificationMaterial = VerificationMaterial(
+                    format = VerificationMaterialFormat.MULTIBASE,
+                    value = "zrv2DyJwnoQWzS74nPkHHdM7NYH27BRNFBG9To7Fca9YzWhfBVa9Mek52H9bJexjdNqxML1F3TGCpjLNkCwwgQDvd5J",
+                ),
+            )
+        )
+
+        assertEquals("did:example:eve#key-ed25519-2", key.id)
+        assertEquals(Curve.Ed25519, key.curve)
+        assertEquals(
+            mapOf(
+                "kty" to "OKP",
+                "crv" to "Ed25519",
+                "x" to "VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE",
+                "d" to "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
             ),
             key.jwk.toJSONObject(),
         )


### PR DESCRIPTION
- Added support for Base58 and Multibase key formats for secrets and corresponding unit tests.
- Made a minor correction in getJWSAlgorithm function.